### PR TITLE
feat: 상품 관련 3아키텍처 및 엔티티 dto 추가 서비스에 adjustStock 메소드 추가 order에서 참조용

### DIFF
--- a/src/main/java/com/seventeamproject/api/product/controller/ProductController.java
+++ b/src/main/java/com/seventeamproject/api/product/controller/ProductController.java
@@ -1,0 +1,11 @@
+package com.seventeamproject.api.product.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+}

--- a/src/main/java/com/seventeamproject/api/product/dto/ProductRequest.java
+++ b/src/main/java/com/seventeamproject/api/product/dto/ProductRequest.java
@@ -1,0 +1,4 @@
+package com.seventeamproject.api.product.dto;
+
+public record ProductRequest() {
+}

--- a/src/main/java/com/seventeamproject/api/product/dto/ProductResponse.java
+++ b/src/main/java/com/seventeamproject/api/product/dto/ProductResponse.java
@@ -1,0 +1,4 @@
+package com.seventeamproject.api.product.dto;
+
+public record ProductResponse() {
+}

--- a/src/main/java/com/seventeamproject/api/product/entity/Product.java
+++ b/src/main/java/com/seventeamproject/api/product/entity/Product.java
@@ -1,0 +1,54 @@
+package com.seventeamproject.api.product.entity;
+
+import com.seventeamproject.api.admin.entity.Admin;
+import com.seventeamproject.common.entity.SoftDeletableEntity;
+import com.seventeamproject.example.many.entity.Many;
+import com.seventeamproject.example.one.entity.One;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Getter
+@Entity
+@Table(name = "products",
+        indexes = {
+                @Index(name = "idx_deleted_at", columnList = "deleted_at")
+        })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE products SET deleted_at = now() WHERE id = ?")
+@SQLRestriction("deleted_at IS NULL")
+public class Product extends SoftDeletableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private Long price;
+    private Long totalQty;
+    private String status;
+    private Long categoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "admin_id", nullable = false)
+    private Admin admin;
+
+    private Long value;
+
+    public Product(String name, Long categoryId, Long price, Long totalQty, String status) {
+        this.name = name;
+        this.categoryId = categoryId;
+        this.price = price;
+        this.totalQty = totalQty;
+        this.status = status;
+    }
+
+    public Product update(String name, Long categoryId, Long price) {
+        this.name = name;
+        this.categoryId = categoryId;
+        this.price = price;
+        return this;
+    }
+}

--- a/src/main/java/com/seventeamproject/api/product/repository/ProductRepository.java
+++ b/src/main/java/com/seventeamproject/api/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.seventeamproject.api.product.repository;
+
+import com.seventeamproject.api.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long>{
+}

--- a/src/main/java/com/seventeamproject/api/product/service/ProductService.java
+++ b/src/main/java/com/seventeamproject/api/product/service/ProductService.java
@@ -1,0 +1,15 @@
+package com.seventeamproject.api.product.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductService {
+    @Transactional
+    public boolean adjustStock(Long id, Long qty) {
+        return true;
+    }
+}


### PR DESCRIPTION
## 개요
- [상품 관련 3아키텍처 및 엔티티 dto 추가 서비스에 adjustStock 메소드 추가 order에서 참조용]

## 변경 사항
- 추가 한거라 딱히 변경은 아니고 프로덕트 도메인이 생겼다

## 테스트 방법
- 실행만 되면 된다

## 관련 이슈
- https://github.com/7TeamSpartaSpring/SpartaSevenTeam/issues/28

## 추가 설명
- 일단 주문에서 필요 할 메소드의 껍데기만 만들어 놨다
