### PR TITLE
[feat] #1 관리자 Role/Status 구조 확정

### DIFF
--- a/src/main/java/com/seventeamproject/api/admin/entity/Admin.java
+++ b/src/main/java/com/seventeamproject/api/admin/entity/Admin.java
@@ -1,33 +1,116 @@
 package com.seventeamproject.api.admin.entity;
 
 import com.seventeamproject.api.admin.enums.AdminRoleEnum;
+import com.seventeamproject.api.admin.enums.AdminStatusEnum;
 import com.seventeamproject.common.entity.SoftDeletableEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Entity
 @Table(name = "admin")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Admin extends SoftDeletableEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(unique = true)
-    private String email;
-    private String password;
-    private String name;
-    @Enumerated(EnumType.STRING)
-    private AdminRoleEnum role;
-    private boolean isEnabled;
 
-    public Admin(String email, String password, String name, AdminRoleEnum role, boolean isEnabled) {
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(unique = true, nullable = false)
+    private String phone;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdminRoleEnum role;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdminStatusEnum status;
+
+    private LocalDateTime approvedAt;
+
+    private LocalDateTime rejectedAt;
+
+    @Column(length = 500)
+    private String rejectedReason;
+
+
+    // 관리자 가입 신청 시 사용하는 생성자
+    public Admin(String email, String password, String name, String phone, AdminRoleEnum role) {
         this.email = email;
         this.password = password;
         this.name = name;
+        this.phone = phone;
         this.role = role;
-        this.isEnabled = isEnabled;
+        this.status = AdminStatusEnum.PENDING;
+    }
+
+    // 로그인 가능 여부
+    public boolean isEnabled() {
+        return this.status == AdminStatusEnum.ACTIVE && !isDeleted();
+    }
+
+    // 승인 처리
+    public void approve() {
+        if (this.status != AdminStatusEnum.PENDING) {
+            throw new IllegalStateException("승인대기 상태만 승인할 수 있습니다.");
+        }
+        this.status = AdminStatusEnum.ACTIVE;
+        this.approvedAt = LocalDateTime.now();
+        this.rejectedAt = null;
+        this.rejectedReason = null;
+    }
+
+    // 거부 처리
+    public void reject(String reason) {
+        if (this.status != AdminStatusEnum.PENDING) {
+            throw new IllegalStateException("승인대기 상태만 거부할 수 있습니다.");
+        }
+        this.status = AdminStatusEnum.REJECTED;
+        this.rejectedAt = LocalDateTime.now();
+        this.rejectedReason = reason;
+    }
+
+    //  역할 변경
+    public void changeRole(AdminRoleEnum role) {
+        this.role = role;
+    }
+
+    // 상태 변경
+    public void changeStatus(AdminStatusEnum status) {
+        this.status = status;
+    }
+
+    // 내 프로필 수정용
+    public void updateProfile(String name, String email, String phone) {
+        this.name = name;
+        this.email = email;
+        this.phone = phone;
+    }
+
+    // 비밀번호 변경
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
+
+    // 시드용
+    public static Admin seed(String email, String encodedPassword, String name, String phone, AdminRoleEnum role) {
+        Admin admin = new Admin(email, encodedPassword, name, phone, role);
+        admin.status = AdminStatusEnum.ACTIVE;
+        admin.approvedAt = LocalDateTime.now();
+        return admin;
     }
 }

--- a/src/main/java/com/seventeamproject/api/admin/enums/AdminRoleEnum.java
+++ b/src/main/java/com/seventeamproject/api/admin/enums/AdminRoleEnum.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AdminRoleEnum {
 
     SUPER_ADMIN("ROLE_SUPER_ADMIN", "슈퍼 관리자"),
-    ADMIN("ROLE_ADMIN", "관리자");
+    OPERATION_ADMIN("ROLE_OPERATION_ADMIN","운영 관리자"),
+    CS_ADMIN("ROLE_CS_ADMIN", "CS 관리자");
 
     private final String authority;
     private final String title;

--- a/src/main/java/com/seventeamproject/api/admin/enums/AdminStatusEnum.java
+++ b/src/main/java/com/seventeamproject/api/admin/enums/AdminStatusEnum.java
@@ -1,0 +1,17 @@
+package com.seventeamproject.api.admin.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminStatusEnum {
+
+    PENDING("승인대기"),
+    ACTIVE("활성"),
+    INACTIVE("비활성"),
+    SUSPENDED("정지"),
+    REJECTED("거부");
+
+    private final String title;
+}

--- a/src/main/java/com/seventeamproject/api/admin/repository/AdminRepository.java
+++ b/src/main/java/com/seventeamproject/api/admin/repository/AdminRepository.java
@@ -7,7 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AdminRepository extends JpaRepository<Admin, Long> {
-    boolean existsByEmail(String email);
+    boolean existsByEmailAndDeletedAtIsNull(String email);
     boolean existsByRole(AdminRoleEnum adminRoleEnum);
-    Optional<Admin> findByEmail(String email);
+    Optional<Admin> findByEmailAndDeletedAtIsNull(String email);
+    Optional<Admin> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/com/seventeamproject/common/init/DataInitRunner.java
+++ b/src/main/java/com/seventeamproject/common/init/DataInitRunner.java
@@ -17,16 +17,41 @@ public class DataInitRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        if (!adminRepository.existsByRole(AdminRoleEnum.SUPER_ADMIN)) {
-            Admin superAdmin = new Admin(
+
+        // 슈퍼 관리자
+        if (!adminRepository.existsByEmailAndDeletedAtIsNull("admin@sparta.com")) {
+            Admin superAdmin = Admin.seed(
                     "admin@sparta.com",
                     passwordEncoder.encode("sparta1234"),
                     "admin",
-                    AdminRoleEnum.SUPER_ADMIN,
-                    true
+                    "010-0000-0000",
+                    AdminRoleEnum.SUPER_ADMIN
             );
             adminRepository.save(superAdmin);
+        }
 
+        // 운영 관리자
+        if (!adminRepository.existsByEmailAndDeletedAtIsNull("operation@sparta.com")) {
+            Admin operationAdmin = Admin.seed(
+                    "operation@sparta.com",
+                    passwordEncoder.encode("sparta1234"),
+                    "김운영",
+                    "010-1111-1111",
+                    AdminRoleEnum.OPERATION_ADMIN
+            );
+            adminRepository.save(operationAdmin);
+        }
+
+        // CS 관리자
+        if (!adminRepository.existsByEmailAndDeletedAtIsNull("cs@sparta.com")) {
+            Admin csAdmin = Admin.seed(
+                    "cs@sparta.com",
+                    passwordEncoder.encode("password123"),
+                    "이고객",
+                    "010-2222-2222",
+                    AdminRoleEnum.CS_ADMIN
+            );
+            adminRepository.save(csAdmin);
         }
     }
 }


### PR DESCRIPTION
Closes #1

- AdminRoleEnum 역할 3종 확정(SUPER/OPERATION/CS)
- AdminStatusEnum 추가(PENDING/ACTIVE/INACTIVE/SUSPENDED/REJECTED)
- Admin 엔티티에 status/phone/승인/거부 필드 반영
- AdminRepository soft delete 제외 조회 메서드 추가
- DataInitRunner 시드 관리자 3명 생성