### PR TITLE
Feat: 관리자 승인/거부 + 프로필 + 비밀번호 변경 기능 추가

### DIFF
--- a/src/main/java/com/seventeamproject/api/admin/controller/AdminController.java
+++ b/src/main/java/com/seventeamproject/api/admin/controller/AdminController.java
@@ -1,31 +1,91 @@
 package com.seventeamproject.api.admin.controller;
 
+import com.seventeamproject.api.admin.dto.ChangePasswordRequest;
+import com.seventeamproject.api.admin.dto.RejectRequest;
+import com.seventeamproject.api.admin.dto.UpdateMeRequest;
+import com.seventeamproject.api.admin.service.AdminService;
+import com.seventeamproject.common.dto.ApiResponse;
 import com.seventeamproject.common.security.principal.PrincipalUser;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/admin")
 public class AdminController {
-    @PreAuthorize("hasAnyRole('SUPER_ADMIN', 'ADMIN')")
-    @GetMapping("/admin/info")
-    public ResponseEntity<String> getAdminInfo(Authentication authentication) {
-        PrincipalUser user = (PrincipalUser) authentication.getPrincipal();
-        String userId = user.getEmail();
 
-        return ResponseEntity.ok("현재 사용자: " + userId);
+    private final AdminService adminService;
+
+    // 관리자 내 프로필 조회
+    @GetMapping("/v1/admin/me")
+    public ResponseEntity<ApiResponse> me(Authentication authentication) {
+        PrincipalUser principal = (PrincipalUser) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(adminService.getMe(principal.getId())));
     }
 
+    // 관리자 내 프로필 수정
+    @PutMapping ("/v1/admin/me")
+    public ResponseEntity<ApiResponse> updateMe(
+            Authentication authentication,
+            @Valid @RequestBody UpdateMeRequest request
+    ) {
+        PrincipalUser principal = (PrincipalUser) authentication.getPrincipal();
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(adminService.updateMe(principal.getId(), request)));
+    }
+
+    // 관리자 내 비밀번호 변경
+    @PatchMapping("/v1/admin/me/password")
+    public ResponseEntity<ApiResponse<String>> changePassword(
+            Authentication authentication,
+            @Valid @RequestBody ChangePasswordRequest request
+    ) {
+        PrincipalUser principal = (PrincipalUser) authentication.getPrincipal();
+
+        adminService.changePassword(principal.getId(), request);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("비밀번호 변경 완료"));
+    }
+
+    // 관리자 승인 (SUPER_ADMIN만 가능)
     @PreAuthorize("hasRole('SUPER_ADMIN')")
-    @GetMapping("/admin/super/info")
-    public ResponseEntity<String> getSuperAdminInfo(Authentication authentication) {
-        PrincipalUser user = (PrincipalUser) authentication.getPrincipal();
-        String userId = user.getEmail();
-
-        return ResponseEntity.ok("현재 사용자: " + userId);
+    @PatchMapping("/v1/admin/{adminId}/approve")
+    public ResponseEntity<ApiResponse> approve(@PathVariable Long adminId) {
+        adminService.approve(adminId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("승인 완료"));
     }
+
+    // 관리자 거부 (SUPER_ADMIN만 가능)
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    @PatchMapping("/v1/admin/{adminId}/reject")
+    public ResponseEntity<ApiResponse<String>> reject(
+            @PathVariable Long adminId,
+            @Valid @RequestBody RejectRequest request
+    ) {
+        adminService.reject(adminId, request.reason());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success("거부 완료"));
+    }
+
+
+//    @PreAuthorize("hasAnyRole('SUPER_ADMIN', 'ADMIN')")
+//    @GetMapping("/admin/info")
+//    public ResponseEntity<String> getAdminInfo(Authentication authentication) {
+//        PrincipalUser user = (PrincipalUser) authentication.getPrincipal();
+//        String userId = user.getEmail();
+//
+//        return ResponseEntity.ok("현재 사용자: " + userId);
+//    }
+//
+//    @PreAuthorize("hasRole('SUPER_ADMIN')")
+//    @GetMapping("/admin/super/info")
+//    public ResponseEntity<String> getSuperAdminInfo(Authentication authentication) {
+//        PrincipalUser user = (PrincipalUser) authentication.getPrincipal();
+//        String userId = user.getEmail();
+//
+//        return ResponseEntity.ok("현재 사용자: " + userId);
+//    }
 }

--- a/src/main/java/com/seventeamproject/api/admin/dto/AdminMeResponse.java
+++ b/src/main/java/com/seventeamproject/api/admin/dto/AdminMeResponse.java
@@ -1,0 +1,25 @@
+package com.seventeamproject.api.admin.dto;
+
+public record AdminMeResponse(
+        Long id,
+        String email,
+        String name,
+        String phone,
+        com.seventeamproject.api.admin.enums.AdminRoleEnum role,
+        com.seventeamproject.api.admin.enums.AdminStatusEnum status,
+        java.time.LocalDateTime createdAt,
+        java.time.LocalDateTime modifiedAt
+) {
+    public static AdminMeResponse from(com.seventeamproject.api.admin.entity.Admin admin) {
+        return new AdminMeResponse(
+                admin.getId(),
+                admin.getEmail(),
+                admin.getName(),
+                admin.getPhone(),
+                admin.getRole(),
+                admin.getStatus(),
+                admin.getCreatedAt(),
+                admin.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/seventeamproject/api/admin/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/seventeamproject/api/admin/dto/ChangePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.seventeamproject.api.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+        @NotBlank(message = "현재 비밀번호는 필수입니다")
+        String currentPassword,
+
+        @NotBlank(message = "새 비밀번호는 필수입니다")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상입니다")
+        String newPassword
+) {}

--- a/src/main/java/com/seventeamproject/api/admin/dto/RejectRequest.java
+++ b/src/main/java/com/seventeamproject/api/admin/dto/RejectRequest.java
@@ -1,0 +1,10 @@
+package com.seventeamproject.api.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RejectRequest (
+    @NotBlank(message = "거부 사유는 필수입니다")
+    @Size(max = 500, message = "거부 사유는 500자 이내로 입력해 주세요")
+    String reason
+) {}

--- a/src/main/java/com/seventeamproject/api/admin/dto/UpdateMeRequest.java
+++ b/src/main/java/com/seventeamproject/api/admin/dto/UpdateMeRequest.java
@@ -1,0 +1,18 @@
+package com.seventeamproject.api.admin.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateMeRequest (
+        @NotBlank(message = "이름은 필수입니다")
+        String name,
+
+        @Email(message = "이메일 형식이 올바르지 않습니다")
+        @NotBlank(message = "이메일은 필수입니다")
+        String email,
+
+        @Pattern(regexp = "^010-\\d{4}-\\d{4}$", message = "전화번호 형식은 010-xxxx-xxxx입니다")
+        @NotBlank(message = "전화번호는 필수입니다")
+        String phone
+) {}

--- a/src/main/java/com/seventeamproject/api/admin/entity/Admin.java
+++ b/src/main/java/com/seventeamproject/api/admin/entity/Admin.java
@@ -7,13 +7,17 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Entity
-@Table(name = "admin")
+@Table(name = "admin", indexes = @Index(name = "idx_admin_deleted_at", columnList = "deleted_at"))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE admin SET deleted_at = now() WHERE id = ?")
 public class Admin extends SoftDeletableEntity {
 
     @Id

--- a/src/main/java/com/seventeamproject/api/admin/service/AdminService.java
+++ b/src/main/java/com/seventeamproject/api/admin/service/AdminService.java
@@ -1,0 +1,78 @@
+package com.seventeamproject.api.admin.service;
+
+import com.seventeamproject.api.admin.dto.AdminMeResponse;
+import com.seventeamproject.api.admin.dto.ChangePasswordRequest;
+import com.seventeamproject.api.admin.dto.UpdateMeRequest;
+import com.seventeamproject.api.admin.entity.Admin;
+import com.seventeamproject.api.admin.repository.AdminRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 내 프로필 조회
+    public AdminMeResponse getMe(Long loginAdminId) {
+        Admin admin = getAdminOrThrow(loginAdminId);
+        return AdminMeResponse.from(admin);
+    }
+
+    // 내 프로필 수정
+    @Transactional
+    public AdminMeResponse updateMe(Long loginAdminId, UpdateMeRequest request) {
+        Admin admin = getAdminOrThrow(loginAdminId);
+
+        if (!admin.getEmail().equals(request.email())
+                && adminRepository.existsByEmailAndDeletedAtIsNull(request.email())) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다");
+        }
+
+        if (!admin.getPhone().equals(request.phone())
+                && adminRepository.existsByPhoneAndDeletedAtIsNull(request.phone())) {
+            throw new IllegalArgumentException("이미 사용 중인 전화번호입니다");
+        }
+        admin.updateProfile(request.name(), request.email(), request.phone());
+        return AdminMeResponse.from(admin);
+    }
+
+    // 내 비밀번호 변경
+    @Transactional
+    public void changePassword(Long loginAdminId, ChangePasswordRequest request) {
+        Admin admin = getAdminOrThrow(loginAdminId);
+
+        if (!passwordEncoder.matches(request.currentPassword(), admin.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다");
+        }
+
+        admin.changePassword(passwordEncoder.encode(request.newPassword()));
+    }
+
+    // 승인 (PENDING -> ACTIVE)
+    @Transactional
+    public void approve(Long adminId) {
+        Admin admin = getAdminOrThrow(adminId);
+        admin.approve();
+    }
+
+    // 거부 (PENDING -> REJECTED)
+    @Transactional
+    public void reject(Long adminId, String reason) {
+        Admin admin = getAdminOrThrow(adminId);
+        admin.reject(reason);
+    }
+
+    private Admin getAdminOrThrow(Long adminId) {
+        return adminRepository.findById(adminId).orElseThrow(
+                () -> new IllegalStateException("관리자를 찾을 수 없습니다")
+        );
+    }
+}


### PR DESCRIPTION
Closes #43 

## 변경 사항
- 관리자 승인/거부 기능 추가
- 관리자 내 프로필 조회/수정(me) 기능 추가
- 관리자 비밀번호 변경 기능 추가

## 테스트 방법
- SUPER_ADMIN 토큰으로 approve/reject 200 확인
- 승인된 계정 로그인 성공(JWT 발급) 확인
- /api/admin/v1/admin/me 조회/수정 반영 확인(modifiedAt 변경)
- 비밀번호 변경 후 새 비번으로 로그인 성공 확인
- 일반 관리자 토큰으로 approve/reject 403 확인

